### PR TITLE
Test convertibility of latest unitsTest.txt tests

### DIFF
--- a/icu4c/source/test/intltest/unitstest.cpp
+++ b/icu4c/source/test/intltest/unitstest.cpp
@@ -233,8 +233,10 @@ StringPiece trimField(char *(&field)[2]) {
  * This is a UParseLineFn as required by u_parseDelimitedFile.
  */
 void unitsTestDataLineFn(void *context, char *fields[][2], int32_t fieldCount, UErrorCode *pErrorCode) {
+    if (U_FAILURE(*pErrorCode)) return;
+    UnitsTest* unitsTest = (UnitsTest*)context;
     (void)fieldCount; // unused UParseLineFn variable
-    IcuTestErrorCode status(*(UnitsTest *)context, "unitsTestDatalineFn");
+    IcuTestErrorCode status(*unitsTest, "unitsTestDatalineFn");
 
     StringPiece quantity = trimField(fields[0]);
     StringPiece x = trimField(fields[1]);
@@ -248,27 +250,45 @@ void unitsTestDataLineFn(void *context, char *fields[][2], int32_t fieldCount, U
     unum_close(nf);
 
     MeasureUnit sourceUnit = MeasureUnit::forIdentifier(x, status);
-    if (status.errIfFailureAndReset("forIdentifier(\"%.*s\")", x.length(), x.data())) { return; }
+    if (status.errIfFailureAndReset("forIdentifier(\"%.*s\")", x.length(), x.data())) return;
 
     MeasureUnit targetUnit = MeasureUnit::forIdentifier(y, status);
-    if (status.errIfFailureAndReset("forIdentifier(\"%.*s\")", y.length(), y.data())) { return; }
+    if (status.errIfFailureAndReset("forIdentifier(\"%.*s\")", y.length(), y.data())) return;
+
+    unitsTest->logln("Quantity (Category): \"%.*s\", "
+                     "Expected value of \"1000 %.*s in %.*s\": %f, "
+                     "commentConversionFormula: \"%.*s\", ",
+                     quantity.length(), quantity.data(), x.length(), x.data(), y.length(), y.data(),
+                     expected, commentConversionFormula.length(), commentConversionFormula.data());
 
     // WIP(hugovdm): hook this up to actual tests.
-    //
-    // Possible after merging in younies/tryingdouble:
-    // UnitConverter converter(sourceUnit, targetUnit, *pErrorCode);
-    // double got = converter.convert(1000, *pErrorCode);
-    // ((UnitsTest*)context)->assertEqualsNear(quantity.data(), expected, got, 0.0001);
-    //
-    // In the meantime, printing to stderr.
-    fprintf(stderr,
-            "Quantity (Category): \"%.*s\", "
-            "Expected value of \"1000 %.*s in %.*s\": %f, "
-            "commentConversionFormula: \"%.*s\", "
-            "expected field: \"%.*s\"\n",
-            quantity.length(), quantity.data(), x.length(), x.data(), y.length(), y.data(), expected,
-            commentConversionFormula.length(), commentConversionFormula.data(), utf8Expected.length(),
-            utf8Expected.data());
+
+    // // Convertibility:
+    // MaybeStackVector<MeasureUnit> units;
+    // units.emplaceBack(sourceUnit);
+    // units.emplaceBack(targetUnit);
+    // const auto &conversionRateInfoList = getConversionRatesInfo(units, status);
+    // if (status.errIfFailureAndReset("getConversionRatesInfo(...)")) return;
+
+    // auto actualState = checkUnitsState(sourceUnit, targetUnit, conversionRateInfoList, status);
+    // if (status.errIfFailureAndReset("checkUnitsState(<%s>, <%s>, ...)", sourceUnit.getIdentifier(),
+    //                                 targetUnit.getIdentifier())) {
+    //     return;
+    // }
+
+    // CharString msg;
+    // msg.append("convertible: ", status)
+    //     .append(sourceUnit.getIdentifier(), status)
+    //     .append(" -> ", status)
+    //     .append(targetUnit.getIdentifier(), status);
+    // if (status.errIfFailureAndReset("msg construction")) return;
+
+    // unitsTest->assertTrue(msg.data(), actualState != UNCONVERTIBLE);
+
+    // Unit conversion... untested:
+    // UnitConverter converter(sourceUnit, targetUnit, status);
+    // double got = converter.convert(1000, status);
+    // unitsTest->assertEqualsNear(quantity.data(), expected, got, 0.0001);
 }
 
 /**
@@ -390,12 +410,12 @@ class ExpectedOutput {
 void unitPreferencesTestDataLineFn(void *context, char *fields[][2], int32_t fieldCount,
                                    UErrorCode *pErrorCode) {
     if (U_FAILURE(*pErrorCode)) return;
-    UnitsTest *intltest = (UnitsTest *)context;
-    IcuTestErrorCode status(*(UnitsTest *)context, "unitPreferencesTestDatalineFn");
+    UnitsTest *unitsTest = (UnitsTest *)context;
+    IcuTestErrorCode status(*unitsTest, "unitPreferencesTestDatalineFn");
 
-    if (!intltest->assertTrue(u"unitPreferencesTestDataLineFn expects 9 fields for simple and 11 "
-                              u"fields for compound. Other field counts not yet supported. ",
-                              fieldCount == 9 || fieldCount == 11)) {
+    if (!unitsTest->assertTrue(u"unitPreferencesTestDataLineFn expects 9 fields for simple and 11 "
+                               u"fields for compound. Other field counts not yet supported. ",
+                               fieldCount == 9 || fieldCount == 11)) {
         return;
     }
 
@@ -417,14 +437,12 @@ void unitPreferencesTestDataLineFn(void *context, char *fields[][2], int32_t fie
     dqInputD.setToDecNumber(inputD, status);
     if (status.errIfFailureAndReset("parsing decimal quantity: \"%.*s\"", inputD.length(),
                                     inputD.data())) {
-        *pErrorCode = U_PARSE_ERROR;
         return;
     }
     double inputAmount = dqInputD.toDouble();
 
     MeasureUnit inputMeasureUnit = MeasureUnit::forIdentifier(inputUnit, status);
     if (status.errIfFailureAndReset("forIdentifier(\"%.*s\")", inputUnit.length(), inputUnit.data())) {
-        *pErrorCode = U_PARSE_ERROR;
         return;
     }
 
@@ -434,14 +452,12 @@ void unitPreferencesTestDataLineFn(void *context, char *fields[][2], int32_t fie
     // UnitConverter converter(sourceUnit, targetUnit, *pErrorCode);
     // double got = converter.convert(1000, *pErrorCode);
     // ((UnitsTest*)context)->assertEqualsNear(quantity.data(), expected, got, 0.0001);
-    //
-    // In the meantime, printing to stderr.
-    fprintf(stderr,
-            "Quantity (Category): \"%.*s\", Usage: \"%.*s\", Region: \"%.*s\", "
-            "Input: \"%f %s\", Expected Output: %s\n",
-            quantity.length(), quantity.data(), usage.length(), usage.data(), region.length(),
-            region.data(), inputAmount, inputMeasureUnit.getIdentifier(),
-            output.toDebugString().c_str());
+
+    unitsTest->logln("Quantity (Category): \"%.*s\", Usage: \"%.*s\", Region: \"%.*s\", "
+                     "Input: \"%f %s\", Expected Output: %s",
+                     quantity.length(), quantity.data(), usage.length(), usage.data(), region.length(),
+                     region.data(), inputAmount, inputMeasureUnit.getIdentifier(),
+                     output.toDebugString().c_str());
 }
 
 /**

--- a/icu4c/source/test/intltest/unitstest.cpp
+++ b/icu4c/source/test/intltest/unitstest.cpp
@@ -263,27 +263,27 @@ void unitsTestDataLineFn(void *context, char *fields[][2], int32_t fieldCount, U
 
     // WIP(hugovdm): hook this up to actual tests.
 
-    // // Convertibility:
-    // MaybeStackVector<MeasureUnit> units;
-    // units.emplaceBack(sourceUnit);
-    // units.emplaceBack(targetUnit);
-    // const auto &conversionRateInfoList = getConversionRatesInfo(units, status);
-    // if (status.errIfFailureAndReset("getConversionRatesInfo(...)")) return;
+    // Convertibility:
+    MaybeStackVector<MeasureUnit> units;
+    units.emplaceBack(sourceUnit);
+    units.emplaceBack(targetUnit);
+    const auto &conversionRateInfoList = getConversionRatesInfo(units, status);
+    if (status.errIfFailureAndReset("getConversionRatesInfo(...)")) return;
 
-    // auto actualState = checkUnitsState(sourceUnit, targetUnit, conversionRateInfoList, status);
-    // if (status.errIfFailureAndReset("checkUnitsState(<%s>, <%s>, ...)", sourceUnit.getIdentifier(),
-    //                                 targetUnit.getIdentifier())) {
-    //     return;
-    // }
+    auto actualState = checkUnitsState(sourceUnit, targetUnit, conversionRateInfoList, status);
+    if (status.errIfFailureAndReset("checkUnitsState(<%s>, <%s>, ...)", sourceUnit.getIdentifier(),
+                                    targetUnit.getIdentifier())) {
+        return;
+    }
 
-    // CharString msg;
-    // msg.append("convertible: ", status)
-    //     .append(sourceUnit.getIdentifier(), status)
-    //     .append(" -> ", status)
-    //     .append(targetUnit.getIdentifier(), status);
-    // if (status.errIfFailureAndReset("msg construction")) return;
+    CharString msg;
+    msg.append("convertible: ", status)
+        .append(sourceUnit.getIdentifier(), status)
+        .append(" -> ", status)
+        .append(targetUnit.getIdentifier(), status);
+    if (status.errIfFailureAndReset("msg construction")) return;
 
-    // unitsTest->assertTrue(msg.data(), actualState != UNCONVERTIBLE);
+    unitsTest->assertTrue(msg.data(), actualState != UNCONVERTIBLE);
 
     // Unit conversion... untested:
     // UnitConverter converter(sourceUnit, targetUnit, status);

--- a/icu4c/source/test/testdata/units/unitPreferencesTest.txt
+++ b/icu4c/source/test/testdata/units/unitPreferencesTest.txt
@@ -53,21 +53,21 @@ area;   land;   GB; 1738883619 / 390625;    4451.54206464;  square-meter;   11 /
 area;   land;   GB; 316160658 / 78125;  4046.8564224;   square-meter;   1;  1.0;    acre
 area;   land;   GB; 1422722961 / 390625;    3642.17078016;  square-meter;   9 / 10; 0.9;    acre
 
-#WIP(ILLEGAL_ARG)#concentration;  blood-glucose;  AG; 662435483600000000000000;   6.624354836E23; item-per-cubic-meter;   11 / 10;    1.1;    millimole-per-liter
-#WIP(ILLEGAL_ARG)#concentration;  blood-glucose;  AG; 602214076000000000000000;   6.02214076E23;  item-per-cubic-meter;   1;  1.0;    millimole-per-liter
-#WIP(ILLEGAL_ARG)#concentration;  blood-glucose;  AG; 541992668400000000000000;   5.419926684E23; item-per-cubic-meter;   9 / 10; 0.9;    millimole-per-liter
+concentration;  blood-glucose;  AG; 662435483600000000000000;   6.624354836E23; item-per-cubic-meter;   11 / 10;    1.1;    millimole-per-liter
+concentration;  blood-glucose;  AG; 602214076000000000000000;   6.02214076E23;  item-per-cubic-meter;   1;  1.0;    millimole-per-liter
+concentration;  blood-glucose;  AG; 541992668400000000000000;   5.419926684E23; item-per-cubic-meter;   9 / 10; 0.9;    millimole-per-liter
 
-#WIP(ILLEGAL_ARG)#concentration;  default;    001;    11 / 10;    1.1;    item-per-cubic-meter;   11 / 10;    1.1;    item-per-cubic-meter
-#WIP(ILLEGAL_ARG)#concentration;  default;    001;    1;  1.0;    item-per-cubic-meter;   1;  1.0;    item-per-cubic-meter
-#WIP(ILLEGAL_ARG)#concentration;  default;    001;    9 / 10; 0.9;    item-per-cubic-meter;   9 / 10; 0.9;    item-per-cubic-meter
+concentration;  default;    001;    11 / 10;    1.1;    item-per-cubic-meter;   11 / 10;    1.1;    item-per-cubic-meter
+concentration;  default;    001;    1;  1.0;    item-per-cubic-meter;   1;  1.0;    item-per-cubic-meter
+concentration;  default;    001;    9 / 10; 0.9;    item-per-cubic-meter;   9 / 10; 0.9;    item-per-cubic-meter
 
-#WIP(ILLEGAL_ARG)#consumption;    default;    001;    11 / 1000000000;    1.1E-8; cubic-meter-per-meter;  11 / 10;    1.1;    liter-per-100-kilometer
-#WIP(ILLEGAL_ARG)#consumption;    default;    001;    1 / 100000000;  1.0E-8; cubic-meter-per-meter;  1;  1.0;    liter-per-100-kilometer
-#WIP(ILLEGAL_ARG)#consumption;    default;    001;    9 / 1000000000; 9.0E-9; cubic-meter-per-meter;  9 / 10; 0.9;    liter-per-100-kilometer
+consumption;    default;    001;    11 / 1000000000;    1.1E-8; cubic-meter-per-meter;  11 / 10;    1.1;    liter-per-100-kilometer
+consumption;    default;    001;    1 / 100000000;  1.0E-8; cubic-meter-per-meter;  1;  1.0;    liter-per-100-kilometer
+consumption;    default;    001;    9 / 1000000000; 9.0E-9; cubic-meter-per-meter;  9 / 10; 0.9;    liter-per-100-kilometer
 
-#WIP(ILLEGAL_ARG)#consumption;    vehicle-fuel;   001;    11 / 1000000000;    1.1E-8; cubic-meter-per-meter;  11 / 10;    1.1;    liter-per-100-kilometer
-#WIP(ILLEGAL_ARG)#consumption;    vehicle-fuel;   001;    1 / 100000000;  1.0E-8; cubic-meter-per-meter;  1;  1.0;    liter-per-100-kilometer
-#WIP(ILLEGAL_ARG)#consumption;    vehicle-fuel;   001;    9 / 1000000000; 9.0E-9; cubic-meter-per-meter;  9 / 10; 0.9;    liter-per-100-kilometer
+consumption;    vehicle-fuel;   001;    11 / 1000000000;    1.1E-8; cubic-meter-per-meter;  11 / 10;    1.1;    liter-per-100-kilometer
+consumption;    vehicle-fuel;   001;    1 / 100000000;  1.0E-8; cubic-meter-per-meter;  1;  1.0;    liter-per-100-kilometer
+consumption;    vehicle-fuel;   001;    9 / 1000000000; 9.0E-9; cubic-meter-per-meter;  9 / 10; 0.9;    liter-per-100-kilometer
 
 consumption;    vehicle-fuel;   BR; 11 / 10000000;  1.1E-6; cubic-meter-per-meter;  11 / 10;    1.1;    liter-per-kilometer
 consumption;    vehicle-fuel;   BR; 1 / 1000000;    1.0E-6; cubic-meter-per-meter;  1;  1.0;    liter-per-kilometer
@@ -311,17 +311,17 @@ pressure;   baromtrc;   001;    110;    110.0;  kilogram-per-meter-square-second
 pressure;   baromtrc;   001;    100;    100.0;  kilogram-per-meter-square-second;   1;  1.0;    hectopascal
 pressure;   baromtrc;   001;    90; 90.0;   kilogram-per-meter-square-second;   9 / 10; 0.9;    hectopascal
 
-#WIP(ILLEGAL_ARG)#pressure;   baromtrc;   IN; 37250279 / 10000;   3725.0279;  kilogram-per-meter-square-second;   11 / 10;    1.1;    inch-ofhg
-#WIP(ILLEGAL_ARG)#pressure;   baromtrc;   IN; 3386389 / 1000; 3386.389;   kilogram-per-meter-square-second;   1;  1.0;    inch-ofhg
-#WIP(ILLEGAL_ARG)#pressure;   baromtrc;   IN; 30477501 / 10000;   3047.7501;  kilogram-per-meter-square-second;   9 / 10; 0.9;    inch-ofhg
+pressure;   baromtrc;   IN; 37250279 / 10000;   3725.0279;  kilogram-per-meter-square-second;   11 / 10;    1.1;    inch-ofhg
+pressure;   baromtrc;   IN; 3386389 / 1000; 3386.389;   kilogram-per-meter-square-second;   1;  1.0;    inch-ofhg
+pressure;   baromtrc;   IN; 30477501 / 10000;   3047.7501;  kilogram-per-meter-square-second;   9 / 10; 0.9;    inch-ofhg
 
 pressure;   baromtrc;   BR; 110;    110.0;  kilogram-per-meter-square-second;   11 / 10;    1.1;    millibar
 pressure;   baromtrc;   BR; 100;    100.0;  kilogram-per-meter-square-second;   1;  1.0;    millibar
 pressure;   baromtrc;   BR; 90; 90.0;   kilogram-per-meter-square-second;   9 / 10; 0.9;    millibar
 
-#WIP(ILLEGAL_ARG)#pressure;   baromtrc;   MX; 44583 / 3040;   14.66546052631579;  kilogram-per-meter-square-second;   11 / 10;    1.1;    millimeter-ofhg
-#WIP(ILLEGAL_ARG)#pressure;   baromtrc;   MX; 4053 / 304; 13.33223684210526;  kilogram-per-meter-square-second;   1;  1.0;    millimeter-ofhg
-#WIP(ILLEGAL_ARG)#pressure;   baromtrc;   MX; 36477 / 3040;   11.99901315789474;  kilogram-per-meter-square-second;   9 / 10; 0.9;    millimeter-ofhg
+pressure;   baromtrc;   MX; 44583 / 3040;   14.66546052631579;  kilogram-per-meter-square-second;   11 / 10;    1.1;    millimeter-ofhg
+pressure;   baromtrc;   MX; 4053 / 304; 13.33223684210526;  kilogram-per-meter-square-second;   1;  1.0;    millimeter-ofhg
+pressure;   baromtrc;   MX; 36477 / 3040;   11.99901315789474;  kilogram-per-meter-square-second;   9 / 10; 0.9;    millimeter-ofhg
 
 pressure;   default;    001;    1100000;    1100000.0;  kilogram-per-meter-square-second;   11 / 10;    1.1;    megapascal
 pressure;   default;    001;    1000000;    1000000.0;  kilogram-per-meter-square-second;   1;  1.0;    megapascal

--- a/icu4c/source/test/testdata/units/unitPreferencesTest.txt
+++ b/icu4c/source/test/testdata/units/unitPreferencesTest.txt
@@ -15,7 +15,7 @@
 #      length; person-height; CA; 3429 / 12500; 0.27432; meter; 2; foot; 54 / 5; 10.8; inch
 #    The input and output units are unit identifers; they are neither localized nor adjusted for pluralization,#     nor formatted with the skeleton.
 #
-# Generation: Set SHOW_DATA in TestUnits.java, and look at TestUnitPreferences results.
+# Generation: Set GENERATE_TESTS in TestUnits.java, and look at TestUnitPreferences results.
 
 area;   default;    001;    1100000;    1100000.0;  square-meter;   11 / 10;    1.1;    square-kilometer
 area;   default;    001;    1000000;    1000000.0;  square-meter;   1;  1.0;    square-kilometer
@@ -153,7 +153,9 @@ length; person-height;  001;    9 / 1000;   0.009;  meter;  9 / 10; 0.9;    cent
 
 length; person-height;  CA; 381 / 12500;    0.03048;    meter;  3;  foot;   6 / 5;  1.2;    inch
 length; person-height;  CA; 0;  0.0;    meter;  3;  foot;   0;  0.0;    inch
-length; person-height;  CA; 3429 / 12500;   0.27432;    meter;  2;  foot;   54 / 5; 10.8;   inch
+length; person-height;  CA; 11049 / 12500;  0.88392;    meter;  174 / 5;    34.8;   inch
+length; person-height;  CA; 127 / 5000; 0.0254; meter;  1;  1.0;    inch
+length; person-height;  CA; 1143 / 50000;   0.02286;    meter;  9 / 10; 0.9;    inch
 
 length; person-height;  AT; 1 / 10; 0.1;    meter;  1;  meter;  10; 10.0;   centimeter
 length; person-height;  AT; 0;  0.0;    meter;  1;  meter;  0;  0.0;    centimeter
@@ -195,9 +197,15 @@ length; road;   GB; 1141857 / 12500;    91.34856;   meter;  999 / 10;   99.9;   
 length; road;   GB; 1143 / 1250;    0.9144; meter;  1;  1.0;    yard
 length; road;   GB; 10287 / 12500;  0.82296;    meter;  9 / 10; 0.9;    yard
 
-length; road;   SE; 2000;   2000.0; meter;  1 / 5;  0.2;    mile-scandinavian
-length; road;   SE; 1000;   1000.0; meter;  1 / 10; 0.1;    mile-scandinavian
-length; road;   SE; 0;  0.0;    meter;  0;  0.0;    mile-scandinavian
+length; road;   SE; 11000;  11000.0;    meter;  11 / 10;    1.1;    mile-scandinavian
+length; road;   SE; 10000;  10000.0;    meter;  1;  1.0;    mile-scandinavian
+length; road;   SE; 9000;   9000.0; meter;  9;  9.0;    kilometer
+length; road;   SE; 1000;   1000.0; meter;  1;  1.0;    kilometer
+length; road;   SE; 900;    900.0;  meter;  900;    900.0;  meter
+length; road;   SE; 300;    300.0;  meter;  300;    300.0;  meter
+length; road;   SE; 2999 / 10;  299.9;  meter;  2999 / 10;  299.9;  meter
+length; road;   SE; 1;  1.0;    meter;  1;  1.0;    meter
+length; road;   SE; 9 / 10; 0.9;    meter;  9 / 10; 0.9;    meter
 
 length; snowfall;   001;    11 / 1000;  0.011;  meter;  11 / 10;    1.1;    centimeter
 length; snowfall;   001;    1 / 100;    0.01;   meter;  1;  1.0;    centimeter
@@ -311,17 +319,17 @@ pressure;   baromtrc;   001;    110;    110.0;  kilogram-per-meter-square-second
 pressure;   baromtrc;   001;    100;    100.0;  kilogram-per-meter-square-second;   1;  1.0;    hectopascal
 pressure;   baromtrc;   001;    90; 90.0;   kilogram-per-meter-square-second;   9 / 10; 0.9;    hectopascal
 
-pressure;   baromtrc;   IN; 37250279 / 10000;   3725.0279;  kilogram-per-meter-square-second;   11 / 10;    1.1;    inch-ofhg
-pressure;   baromtrc;   IN; 3386389 / 1000; 3386.389;   kilogram-per-meter-square-second;   1;  1.0;    inch-ofhg
-pressure;   baromtrc;   IN; 30477501 / 10000;   3047.7501;  kilogram-per-meter-square-second;   9 / 10; 0.9;    inch-ofhg
+pressure;   baromtrc;   IN; 37250275043751 / 10000000000;   3725.0275043751;    kilogram-per-meter-square-second;   11 / 10;    1.1;    inch-ofhg
+pressure;   baromtrc;   IN; 3386388640341 / 1000000000; 3386.388640341; kilogram-per-meter-square-second;   1;  1.0;    inch-ofhg
+pressure;   baromtrc;   IN; 30477497763069 / 10000000000;   3047.7497763069;    kilogram-per-meter-square-second;   9 / 10; 0.9;    inch-ofhg
 
 pressure;   baromtrc;   BR; 110;    110.0;  kilogram-per-meter-square-second;   11 / 10;    1.1;    millibar
 pressure;   baromtrc;   BR; 100;    100.0;  kilogram-per-meter-square-second;   1;  1.0;    millibar
 pressure;   baromtrc;   BR; 90; 90.0;   kilogram-per-meter-square-second;   9 / 10; 0.9;    millibar
 
-pressure;   baromtrc;   MX; 44583 / 3040;   14.66546052631579;  kilogram-per-meter-square-second;   11 / 10;    1.1;    millimeter-ofhg
-pressure;   baromtrc;   MX; 4053 / 304; 13.33223684210526;  kilogram-per-meter-square-second;   1;  1.0;    millimeter-ofhg
-pressure;   baromtrc;   MX; 36477 / 3040;   11.99901315789474;  kilogram-per-meter-square-second;   9 / 10; 0.9;    millimeter-ofhg
+pressure;   baromtrc;   MX; 293309252313 / 2000000000;  146.6546261565; kilogram-per-meter-square-second;   11 / 10;    1.1;    millimeter-ofhg
+pressure;   baromtrc;   MX; 26664477483 / 200000000;    133.322387415;  kilogram-per-meter-square-second;   1;  1.0;    millimeter-ofhg
+pressure;   baromtrc;   MX; 239980297347 / 2000000000;  119.9901486735; kilogram-per-meter-square-second;   9 / 10; 0.9;    millimeter-ofhg
 
 pressure;   default;    001;    1100000;    1100000.0;  kilogram-per-meter-square-second;   11 / 10;    1.1;    megapascal
 pressure;   default;    001;    1000000;    1000000.0;  kilogram-per-meter-square-second;   1;  1.0;    megapascal

--- a/icu4c/source/test/testdata/units/unitsTest.txt
+++ b/icu4c/source/test/testdata/units/unitsTest.txt
@@ -10,175 +10,182 @@
 #   round to 4 decimal digits before comparing.
 # Note that certain conversions are approximate, such as degrees to radians
 #
-# Generation: Set SHOW_DATA in TestUnits.java, and look at TestParseUnit results.
+# Generation: Set GENERATE_TESTS in TestUnits.java, and look at TestParseUnit results.
 
 acceleration    ;   meter-per-square-second ;   meter-per-square-second ;   1 * x   ;   1,000.00
-acceleration    ;   g-force ;   meter-per-square-second ;   196133 / 20000 * x  ;   9806.65
-angle   ;   arc-second  ;   revolution  ;   1 / 1296000 * x ;   7.716049E-4
-angle   ;   arc-minute  ;   revolution  ;   1 / 21600 * x   ;   0.0462963
-angle   ;   degree  ;   revolution  ;   1 / 360 * x ;   2.777778
-angle   ;   radian  ;   revolution  ;   65501488 / 411557987 * x    ;   159.1549
+acceleration    ;   g-force ;   meter-per-square-second ;   9.80665 * x ;   9806.65
+angle   ;   arc-second  ;   revolution  ;   0.0000625/81 * x    ;   7.716049E-4
+angle   ;   arc-minute  ;   revolution  ;   0.00125/27 * x  ;   0.0462963
+angle   ;   degree  ;   revolution  ;   0.025/9 * x ;   2.777778
+angle   ;   radian  ;   revolution  ;   65,501,488/411,557,987 * x  ;   159.1549
 angle   ;   revolution  ;   revolution  ;   1 * x   ;   1,000.00
-area    ;   square-centimeter   ;   square-meter    ;   1 / 10000 * x   ;   0.1
-area    ;   square-inch ;   square-meter    ;   16129 / 25000000 * x    ;   0.64516
-area    ;   square-foot ;   square-meter    ;   145161 / 1562500 * x    ;   92.90304
-area    ;   square-yard ;   square-meter    ;   1306449 / 1562500 * x   ;   836.1274
+area    ;   square-centimeter   ;   square-meter    ;   0.0001 * x  ;   0.1
+area    ;   square-inch ;   square-meter    ;   0.00064516 * x  ;   0.64516
+area    ;   square-foot ;   square-meter    ;   0.09290304 * x  ;   92.90304
+area    ;   square-yard ;   square-meter    ;   0.83612736 * x  ;   836.1274
 area    ;   square-meter    ;   square-meter    ;   1 * x   ;   1,000.00
-area    ;   dunam   ;   square-meter    ;   1000 * x    ;   1000000.0
-area    ;   acre    ;   square-meter    ;   316160658 / 78125 * x   ;   4046856.0
-area    ;   hectare ;   square-meter    ;   10000 * x   ;   1.0E7
-area    ;   square-kilometer    ;   square-meter    ;   1000000 * x ;   1.0E9
-area    ;   square-mile ;   square-meter    ;   40468564224 / 15625 * x ;   2.589988E9
-concentration   ;   millimole-per-liter ;   item-per-cubic-meter    ;   602214076000000000000000 * x    ;   6.022141E26
-consumption ;   liter-per-100-kilometer ;   cubic-meter-per-meter   ;   1 / 100000000 * x   ;   1.0E-5
-consumption ;   liter-per-kilometer ;   cubic-meter-per-meter   ;   1 / 1000000 * x ;   0.001
-consumption-inverse ;   mile-per-gallon-imperial    ;   meter-per-cubic-meter   ;   160934400000 / 454609 * x   ;   3.540062E8
-consumption-inverse ;   mile-per-gallon ;   meter-per-cubic-meter   ;   48000000000 / 112903 * x    ;   4.251437E8
+area    ;   dunam   ;   square-meter    ;   1,000 * x   ;   1000000.0
+area    ;   acre    ;   square-meter    ;   4,046.8564224 * x   ;   4046856.0
+area    ;   hectare ;   square-meter    ;   10,000 * x  ;   1.0E7
+area    ;   square-kilometer    ;   square-meter    ;   1,000,000 * x   ;   1.0E9
+area    ;   square-mile ;   square-meter    ;   2,589,988.110336 * x    ;   2.589988E9
+concentration   ;   millimole-per-liter ;   item-per-cubic-meter    ;   602,214,076,000,000,000,000,000 * x ;   6.022141E26
+consumption ;   liter-per-100-kilometer ;   cubic-meter-per-meter   ;   0.00000001 * x  ;   1.0E-5
+consumption ;   liter-per-kilometer ;   cubic-meter-per-meter   ;   0.000001 * x    ;   0.001
+consumption-inverse ;   mile-per-gallon-imperial    ;   meter-per-cubic-meter   ;   160,934,400,000/454,609 * x ;   3.540062E8
+consumption-inverse ;   mile-per-gallon ;   meter-per-cubic-meter   ;   48,000,000,000/112,903 * x  ;   4.251437E8
 digital ;   bit ;   bit ;   1 * x   ;   1,000.00
 digital ;   byte    ;   bit ;   8 * x   ;   8000.0
-digital ;   kilobit ;   bit ;   1000 * x    ;   1000000.0
-digital ;   kilobyte    ;   bit ;   8000 * x    ;   8000000.0
-digital ;   megabit ;   bit ;   1000000 * x ;   1.0E9
-digital ;   megabyte    ;   bit ;   8000000 * x ;   8.0E9
-digital ;   gigabit ;   bit ;   1000000000 * x  ;   1.0E12
-digital ;   gigabyte    ;   bit ;   8000000000 * x  ;   8.0E12
-digital ;   terabit ;   bit ;   1000000000000 * x   ;   1.0E15
-digital ;   terabyte    ;   bit ;   8000000000000 * x   ;   8.0E15
-digital ;   petabyte    ;   bit ;   8000000000000000 * x    ;   8.0E18
-duration    ;   nanosecond  ;   second  ;   1 / 1000000000 * x  ;   1.0E-6
-duration    ;   microsecond ;   second  ;   1 / 1000000 * x ;   0.001
-duration    ;   millisecond ;   second  ;   1 / 1000 * x    ;   1.0
+digital ;   kilobit ;   bit ;   1,000 * x   ;   1000000.0
+digital ;   kilobyte    ;   bit ;   8,000 * x   ;   8000000.0
+digital ;   megabit ;   bit ;   1,000,000 * x   ;   1.0E9
+digital ;   megabyte    ;   bit ;   8,000,000 * x   ;   8.0E9
+digital ;   gigabit ;   bit ;   1,000,000,000 * x   ;   1.0E12
+digital ;   gigabyte    ;   bit ;   8,000,000,000 * x   ;   8.0E12
+digital ;   terabit ;   bit ;   1,000,000,000,000 * x   ;   1.0E15
+digital ;   terabyte    ;   bit ;   8,000,000,000,000 * x   ;   8.0E15
+digital ;   petabyte    ;   bit ;   8,000,000,000,000,000 * x   ;   8.0E18
+duration    ;   nanosecond  ;   second  ;   0.000000001 * x ;   1.0E-6
+duration    ;   microsecond ;   second  ;   0.000001 * x    ;   0.001
+duration    ;   millisecond ;   second  ;   0.001 * x   ;   1.0
 duration    ;   second  ;   second  ;   1 * x   ;   1,000.00
 duration    ;   minute  ;   second  ;   60 * x  ;   60000.0
-duration    ;   hour    ;   second  ;   3600 * x    ;   3600000.0
-duration    ;   day ;   second  ;   86400 * x   ;   8.64E7
-duration    ;   day-person  ;   second  ;   86400 * x   ;   8.64E7
-duration    ;   week    ;   second  ;   604800 * x  ;   6.048E8
-duration    ;   week-person ;   second  ;   604800 * x  ;   6.048E8
-electric-current    ;   milliampere ;   ampere  ;   1 / 1000 * x    ;   1.0
+duration    ;   hour    ;   second  ;   3,600 * x   ;   3600000.0
+duration    ;   day ;   second  ;   86,400 * x  ;   8.64E7
+duration    ;   day-person  ;   second  ;   86,400 * x  ;   8.64E7
+duration    ;   week    ;   second  ;   604,800 * x ;   6.048E8
+duration    ;   week-person ;   second  ;   604,800 * x ;   6.048E8
+electric-current    ;   milliampere ;   ampere  ;   0.001 * x   ;   1.0
 electric-current    ;   ampere  ;   ampere  ;   1 * x   ;   1,000.00
 electric-resistance ;   ohm ;   kilogram-square-meter-per-cubic-second-square-ampere    ;   1 * x   ;   1000.0
-energy  ;   electronvolt    ;   kilogram-square-meter-per-square-second ;   1602177 / 10000000000000000000000000 * x    ;   1.602177E-16
-energy  ;   dalton  ;   kilogram-square-meter-per-square-second ;   1865522607 / 12500000000000000000 * x   ;   1.492418E-7
+energy  ;   electronvolt    ;   kilogram-square-meter-per-square-second ;   0.0000000000000000001602177 * x ;   1.602177E-16
+energy  ;   dalton  ;   kilogram-square-meter-per-square-second ;   0.00000000014924180856 * x  ;   1.492418E-7
 energy  ;   joule   ;   kilogram-square-meter-per-square-second ;   1 * x   ;   1000.0
 energy  ;   newton-meter    ;   kilogram-square-meter-per-square-second ;   1 * x   ;   1000.0
-energy  ;   pound-force-foot    ;   kilogram-square-meter-per-square-second ;   3389544870828501 / 2500000000000000 * x ;   1355.818
-energy  ;   calorie ;   kilogram-square-meter-per-square-second ;   523 / 125 * x   ;   4184.0
-energy  ;   kilojoule   ;   kilogram-square-meter-per-square-second ;   1000 * x    ;   1000000.0
-energy  ;   british-thermal-unit    ;   kilogram-square-meter-per-square-second ;   52753 / 50 * x  ;   1055060.0
-energy  ;   foodcalorie ;   kilogram-square-meter-per-square-second ;   4184 * x    ;   4184000.0
-energy  ;   kilocalorie ;   kilogram-square-meter-per-square-second ;   4184 * x    ;   4184000.0
-energy  ;   kilowatt-hour   ;   kilogram-square-meter-second-per-cubic-second   ;   3600000 * x ;   3.6E9
-energy  ;   therm-us    ;   kilogram-square-meter-per-square-second ;   105506000 * x   ;   1.05506E11
+energy  ;   pound-force-foot    ;   kilogram-square-meter-per-square-second ;   1.3558179483314004 * x  ;   1355.818
+energy  ;   calorie ;   kilogram-square-meter-per-square-second ;   4.184 * x   ;   4184.0
+energy  ;   kilojoule   ;   kilogram-square-meter-per-square-second ;   1,000 * x   ;   1000000.0
+energy  ;   british-thermal-unit    ;   kilogram-square-meter-per-square-second ;   9,489.1523804/9 * x ;   1054350.0
+energy  ;   foodcalorie ;   kilogram-square-meter-per-square-second ;   4,184 * x   ;   4184000.0
+energy  ;   kilocalorie ;   kilogram-square-meter-per-square-second ;   4,184 * x   ;   4184000.0
+energy  ;   kilowatt-hour   ;   kilogram-square-meter-second-per-cubic-second   ;   3,600,000 * x   ;   3.6E9
+energy  ;   therm-us    ;   kilogram-square-meter-per-square-second ;   105,480,400 * x ;   1.054804E11
 force   ;   newton  ;   kilogram-meter-per-square-second    ;   1 * x   ;   1000.0
-force   ;   pound-force ;   kilogram-meter-per-square-second    ;   8896443230521 / 2000000000000 * x   ;   4448.222
+force   ;   pound-force ;   kilogram-meter-per-square-second    ;   4.4482216152605 * x ;   4448.222
 frequency   ;   hertz   ;   revolution-per-second   ;   1 * x   ;   1000.0
-frequency   ;   kilohertz   ;   revolution-per-second   ;   1000 * x    ;   1000000.0
-frequency   ;   megahertz   ;   revolution-per-second   ;   1000000 * x ;   1.0E9
-frequency   ;   gigahertz   ;   revolution-per-second   ;   1000000000 * x  ;   1.0E12
+frequency   ;   kilohertz   ;   revolution-per-second   ;   1,000 * x   ;   1000000.0
+frequency   ;   megahertz   ;   revolution-per-second   ;   1,000,000 * x   ;   1.0E9
+frequency   ;   gigahertz   ;   revolution-per-second   ;   1,000,000,000 * x   ;   1.0E12
+graphics    ;   dot ;   pixel   ;   1 * x   ;   1000.0
 graphics    ;   pixel   ;   pixel   ;   1 * x   ;   1,000.00
-graphics    ;   megapixel   ;   pixel   ;   1000000 * x ;   1.0E9
-length  ;   picometer   ;   meter   ;   1 / 1000000000000 * x   ;   1.0E-9
-length  ;   nanometer   ;   meter   ;   1 / 1000000000 * x  ;   1.0E-6
-length  ;   micrometer  ;   meter   ;   1 / 1000000 * x ;   0.001
-length  ;   point   ;   meter   ;   127 / 360000 * x    ;   0.3527778
-length  ;   millimeter  ;   meter   ;   1 / 1000 * x    ;   1.0
-length  ;   centimeter  ;   meter   ;   1 / 100 * x ;   10.0
-length  ;   inch    ;   meter   ;   127 / 5000 * x  ;   25.4
-length  ;   decimeter   ;   meter   ;   1 / 10 * x  ;   100.0
-length  ;   foot    ;   meter   ;   381 / 1250 * x  ;   304.8
-length  ;   yard    ;   meter   ;   1143 / 1250 * x ;   914.4
+graphics    ;   megapixel   ;   pixel   ;   1,000,000 * x   ;   1.0E9
+length  ;   picometer   ;   meter   ;   0.000000000001 * x  ;   1.0E-9
+length  ;   nanometer   ;   meter   ;   0.000000001 * x ;   1.0E-6
+length  ;   micrometer  ;   meter   ;   0.000001 * x    ;   0.001
+length  ;   point   ;   meter   ;   0.003175/9 * x  ;   0.3527778
+length  ;   millimeter  ;   meter   ;   0.001 * x   ;   1.0
+length  ;   centimeter  ;   meter   ;   0.01 * x    ;   10.0
+length  ;   inch    ;   meter   ;   0.0254 * x  ;   25.4
+length  ;   decimeter   ;   meter   ;   0.1 * x ;   100.0
+length  ;   foot    ;   meter   ;   0.3048 * x  ;   304.8
+length  ;   yard    ;   meter   ;   0.9144 * x  ;   914.4
 length  ;   meter   ;   meter   ;   1 * x   ;   1,000.00
-length  ;   fathom  ;   meter   ;   1143 / 625 * x  ;   1828.8
-length  ;   furlong ;   meter   ;   25146 / 125 * x ;   201168.0
-length  ;   kilometer   ;   meter   ;   1000 * x    ;   1000000.0
-length  ;   mile    ;   meter   ;   201168 / 125 * x    ;   1609344.0
-length  ;   nautical-mile   ;   meter   ;   1852 * x    ;   1852000.0
-length  ;   mile-scandinavian   ;   meter   ;   10000 * x   ;   1.0E7
-length  ;   solar-radius    ;   meter   ;   695700000 * x   ;   6.957E11
-length  ;   astronomical-unit   ;   meter   ;   149597900000 * x    ;   1.495979E14
-length  ;   light-year  ;   meter   ;   9460730000000000 * x    ;   9.46073E18
-length  ;   parsec  ;   meter   ;   30856780000000000 * x   ;   3.085678E19
-#WIP(ILLEGAL_ARG)#luminous-flux   ;   lux ;   candela-square-meter-per-square-meter   ;   1 * x   ;   1000.0
-mass    ;   microgram   ;   kilogram    ;   1 / 1000000000 * x  ;   1.0E-6
-mass    ;   milligram   ;   kilogram    ;   1 / 1000000 * x ;   0.001
-mass    ;   carat   ;   kilogram    ;   1 / 5000 * x    ;   0.2
-mass    ;   gram    ;   kilogram    ;   1 / 1000 * x    ;   1.0
-mass    ;   ounce   ;   kilogram    ;   45359237 / 1600000000 * x   ;   28.34952
-mass    ;   ounce-troy  ;   kilogram    ;   777587 / 25000000 * x   ;   31.10348
-mass    ;   pound   ;   kilogram    ;   45359237 / 100000000 * x    ;   453.5924
+length  ;   fathom  ;   meter   ;   1.8288 * x  ;   1828.8
+length  ;   furlong ;   meter   ;   201.168 * x ;   201168.0
+length  ;   kilometer   ;   meter   ;   1,000 * x   ;   1000000.0
+length  ;   mile    ;   meter   ;   1,609.344 * x   ;   1609344.0
+length  ;   nautical-mile   ;   meter   ;   1,852 * x   ;   1852000.0
+length  ;   mile-scandinavian   ;   meter   ;   10,000 * x  ;   1.0E7
+length  ;   100-kilometer   ;   meter   ;   100,000 * x ;   1.0E8
+length  ;   earth-radius    ;   meter   ;   6,378,100 * x   ;   6.3781E9
+length  ;   solar-radius    ;   meter   ;   695,700,000 * x ;   6.957E11
+length  ;   astronomical-unit   ;   meter   ;   149,597,900,000 * x ;   1.495979E14
+length  ;   light-year  ;   meter   ;   9,460,730,000,000,000 * x   ;   9.46073E18
+length  ;   parsec  ;   meter   ;   30,856,780,000,000,000 * x  ;   3.085678E19
+luminous-flux   ;   lux ;   candela-square-meter-per-square-meter   ;   1 * x   ;   1000.0
+luminous-intensity  ;   candela ;   candela ;   1 * x   ;   1,000.00
+mass    ;   microgram   ;   kilogram    ;   0.000000001 * x ;   1.0E-6
+mass    ;   milligram   ;   kilogram    ;   0.000001 * x    ;   0.001
+mass    ;   carat   ;   kilogram    ;   0.0002 * x  ;   0.2
+mass    ;   gram    ;   kilogram    ;   0.001 * x   ;   1.0
+mass    ;   ounce   ;   kilogram    ;   0.028349523125 * x  ;   28.34952
+mass    ;   ounce-troy  ;   kilogram    ;   0.03110348 * x  ;   31.10348
+mass    ;   pound   ;   kilogram    ;   0.45359237 * x  ;   453.5924
 mass    ;   kilogram    ;   kilogram    ;   1 * x   ;   1,000.00
-mass    ;   stone   ;   kilogram    ;   317514659 / 50000000 * x    ;   6350.293
-mass    ;   ton ;   kilogram    ;   45359237 / 50000 * x    ;   907184.7
-mass    ;   metric-ton  ;   kilogram    ;   1000 * x    ;   1000000.0
-mass    ;   earth-mass  ;   kilogram    ;   5972200000000000000000000 * x   ;   5.9722E27
-mass    ;   solar-mass  ;   kilogram    ;   1988470000000000000000000000000 * x ;   1.98847E33
-mass-density    ;   milligram-per-deciliter ;   kilogram-per-cubic-meter    ;   1 / 100 * x ;   10.0
-portion ;   permillion  ;   portion ;   1 / 1000000 * x ;   0.001
-portion ;   permyriad   ;   portion ;   1 / 10000 * x   ;   0.1
-portion ;   permille    ;   portion ;   1 / 1000 * x    ;   1.0
-portion ;   percent ;   portion ;   1 / 100 * x ;   10.0
-portion ;   karat   ;   portion ;   1 / 24 * x  ;   41.66667
-power   ;   milliwatt   ;   kilogram-square-meter-per-cubic-second  ;   1 / 1000 * x    ;   1.0
+mass    ;   stone   ;   kilogram    ;   6.35029318 * x  ;   6350.293
+mass    ;   ton ;   kilogram    ;   907.18474 * x   ;   907184.7
+mass    ;   metric-ton  ;   kilogram    ;   1,000 * x   ;   1000000.0
+mass    ;   earth-mass  ;   kilogram    ;   5,972,200,000,000,000,000,000,000 * x   ;   5.9722E27
+mass    ;   solar-mass  ;   kilogram    ;   1,988,470,000,000,000,000,000,000,000,000 * x   ;   1.98847E33
+mass-density    ;   milligram-per-deciliter ;   kilogram-per-cubic-meter    ;   0.01 * x    ;   10.0
+portion ;   permillion  ;   portion ;   0.000001 * x    ;   0.001
+portion ;   permyriad   ;   portion ;   0.0001 * x  ;   0.1
+portion ;   permille    ;   portion ;   0.001 * x   ;   1.0
+portion ;   percent ;   portion ;   0.01 * x    ;   10.0
+portion ;   karat   ;   portion ;   0.125/3 * x ;   41.66667
+portion ;   portion ;   portion ;   1 * x   ;   1,000.00
+power   ;   milliwatt   ;   kilogram-square-meter-per-cubic-second  ;   0.001 * x   ;   1.0
 power   ;   watt    ;   kilogram-square-meter-per-cubic-second  ;   1 * x   ;   1000.0
-power   ;   horsepower  ;   kilogram-square-meter-per-cubic-second  ;   37284993579113511 / 50000000000000 * x  ;   745699.9
-power   ;   kilowatt    ;   kilogram-square-meter-per-cubic-second  ;   1000 * x    ;   1000000.0
-power   ;   megawatt    ;   kilogram-square-meter-per-cubic-second  ;   1000000 * x ;   1.0E9
-power   ;   gigawatt    ;   kilogram-square-meter-per-cubic-second  ;   1000000000 * x  ;   1.0E12
-power   ;   solar-luminosity    ;   kilogram-square-meter-per-cubic-second  ;   382800000000000000000000000 * x ;   3.828E29
+power   ;   horsepower  ;   kilogram-square-meter-per-cubic-second  ;   745.69987158227022 * x  ;   745699.9
+power   ;   kilowatt    ;   kilogram-square-meter-per-cubic-second  ;   1,000 * x   ;   1000000.0
+power   ;   megawatt    ;   kilogram-square-meter-per-cubic-second  ;   1,000,000 * x   ;   1.0E9
+power   ;   gigawatt    ;   kilogram-square-meter-per-cubic-second  ;   1,000,000,000 * x   ;   1.0E12
+power   ;   solar-luminosity    ;   kilogram-square-meter-per-cubic-second  ;   382,800,000,000,000,000,000,000,000 * x ;   3.828E29
 pressure    ;   pascal  ;   kilogram-per-meter-square-second    ;   1 * x   ;   1000.0
-pressure    ;   millimeter-ofhg   ;   kilogram-per-meter-square-second    ;   4053 / 304 * x  ;   13332.24
 pressure    ;   hectopascal ;   kilogram-per-meter-square-second    ;   100 * x ;   100000.0
 pressure    ;   millibar    ;   kilogram-per-meter-square-second    ;   100 * x ;   100000.0
-pressure    ;   kilopascal  ;   kilogram-per-meter-square-second    ;   1000 * x    ;   1000000.0
-pressure    ;   inch-ofhg   ;   kilogram-per-meter-square-second    ;   3386389 / 1000 * x  ;   338638.8
-pressure    ;   pound-force-per-square-inch ;   kilogram-meter-per-square-meter-square-second   ;   8896443230521 / 1290320000 * x  ;   6894757.0
-pressure    ;   bar ;   kilogram-per-meter-square-second    ;   100000 * x  ;   1.0E8
-pressure    ;   atmosphere  ;   kilogram-per-meter-square-second    ;   101325 * x  ;   1.01325E8
-pressure    ;   megapascal  ;   kilogram-per-meter-square-second    ;   1000000 * x ;   1.0E9
-resolution  ;   dot-per-inch    ;   pixel-per-meter ;   5000 / 127 * x  ;   39370.08
-resolution  ;   pixel-per-inch  ;   pixel-per-meter ;   5000 / 127 * x  ;   39370.08
+pressure    ;   millimeter-ofhg ;   kilogram-meter-per-square-meter-square-second   ;   133.322387415 * x   ;   133322.4
+pressure    ;   kilopascal  ;   kilogram-per-meter-square-second    ;   1,000 * x   ;   1000000.0
+pressure    ;   inch-ofhg   ;   kilogram-meter-per-square-meter-square-second   ;   3,386.388640341 * x ;   3386389.0
+pressure    ;   pound-force-per-square-inch ;   kilogram-meter-per-square-meter-square-second   ;   111,205,540.3815125/16,129 * x  ;   6894757.0
+pressure    ;   bar ;   kilogram-per-meter-square-second    ;   100,000 * x ;   1.0E8
+pressure    ;   atmosphere  ;   kilogram-per-meter-square-second    ;   101,325 * x ;   1.01325E8
+pressure    ;   megapascal  ;   kilogram-per-meter-square-second    ;   1,000,000 * x   ;   1.0E9
+pressure-per-length ;   ofhg    ;   kilogram-per-square-meter-square-second ;   133,322.387415 * x  ;   1.333224E8
+resolution  ;   dot-per-inch    ;   pixel-per-meter ;   5,000/127 * x   ;   39370.08
+resolution  ;   pixel-per-inch  ;   pixel-per-meter ;   5,000/127 * x   ;   39370.08
 resolution  ;   dot-per-centimeter  ;   pixel-per-meter ;   100 * x ;   100000.0
 resolution  ;   pixel-per-centimeter    ;   pixel-per-meter ;   100 * x ;   100000.0
-speed   ;   kilometer-per-hour  ;   meter-per-second    ;   5 / 18 * x  ;   277.7778
-speed   ;   mile-per-hour   ;   meter-per-second    ;   1397 / 3125 * x ;   447.04
-speed   ;   knot    ;   meter-per-second    ;   463 / 900 * x   ;   514.4444
+speed   ;   kilometer-per-hour  ;   meter-per-second    ;   2.5/9 * x   ;   277.7778
+speed   ;   mile-per-hour   ;   meter-per-second    ;   0.44704 * x ;   447.04
+speed   ;   knot    ;   meter-per-second    ;   4.63/9 * x  ;   514.4444
 speed   ;   meter-per-second    ;   meter-per-second    ;   1 * x   ;   1,000.00
-substance-amount    ;   mole    ;   item    ;   602214076000000000000000 * x    ;   6.022141E26
-temperature ;   fahrenheit  ;   kelvin  ;   5 / 9 * x - 45967 / 180 ;   810.9278
+substance-amount    ;   item    ;   item    ;   1 * x   ;   1,000.00
+substance-amount    ;   mole    ;   item    ;   602,214,076,000,000,000,000,000 * x ;   6.022141E26
+temperature ;   fahrenheit  ;   kelvin  ;   5/9 * x - 2,298.35/9    ;   810.9278
 temperature ;   kelvin  ;   kelvin  ;   1 * x   ;   1,000.00
-temperature ;   celsius ;   kelvin  ;   1 * x - 5463 / 20   ;   1273.15
+temperature ;   celsius ;   kelvin  ;   1 * x - 273.15  ;   1273.15
 typewidth   ;   em  ;   em  ;   1 * x   ;   1,000.00
 voltage ;   volt    ;   kilogram-square-meter-per-cubic-second-ampere   ;   1 * x   ;   1000.0
-volume  ;   cubic-centimeter    ;   cubic-meter ;   1 / 1000000 * x ;   0.001
-volume  ;   milliliter  ;   cubic-meter ;   1 / 1000000 * x ;   0.001
-volume  ;   teaspoon    ;   cubic-meter ;   157725491 / 32000000000000 * x  ;   0.004928922
-volume  ;   centiliter  ;   cubic-meter ;   1 / 100000 * x  ;   0.01
-volume  ;   tablespoon  ;   cubic-meter ;   473176473 / 32000000000000 * x  ;   0.01478676
-volume  ;   cubic-inch  ;   cubic-meter ;   2048383 / 125000000000 * x  ;   0.01638706
-volume  ;   fluid-ounce-imperial    ;   cubic-meter ;   454609 / 16000000000 * x    ;   0.02841306
-volume  ;   fluid-ounce ;   cubic-meter ;   473176473 / 16000000000000 * x  ;   0.02957353
-volume  ;   deciliter   ;   cubic-meter ;   1 / 10000 * x   ;   0.1
-volume  ;   cup ;   cubic-meter ;   473176473 / 2000000000000 * x   ;   0.2365882
-volume  ;   cup-metric  ;   cubic-meter ;   1 / 4000 * x    ;   0.25
-volume  ;   pint    ;   cubic-meter ;   473176473 / 1000000000000 * x   ;   0.4731765
-volume  ;   pint-metric ;   cubic-meter ;   1 / 2000 * x    ;   0.5
-volume  ;   quart   ;   cubic-meter ;   473176473 / 500000000000 * x    ;   0.9463529
-volume  ;   liter   ;   cubic-meter ;   1 / 1000 * x    ;   1.0
-volume  ;   gallon  ;   cubic-meter ;   473176473 / 125000000000 * x    ;   3.785412
-volume  ;   gallon-imperial ;   cubic-meter ;   454609 / 100000000 * x  ;   4.54609
-volume  ;   cubic-foot  ;   cubic-meter ;   55306341 / 1953125000 * x   ;   28.31685
-volume  ;   bushel  ;   cubic-meter ;   220244188543 / 6250000000000 * x    ;   35.23907
-volume  ;   hectoliter  ;   cubic-meter ;   1 / 10 * x  ;   100.0
-volume  ;   barrel  ;   cubic-meter ;   9936705933 / 62500000000 * x    ;   158.9873
-volume  ;   cubic-yard  ;   cubic-meter ;   1493271207 / 1953125000 * x ;   764.5549
+volume  ;   cubic-centimeter    ;   cubic-meter ;   0.000001 * x    ;   0.001
+volume  ;   milliliter  ;   cubic-meter ;   0.000001 * x    ;   0.001
+volume  ;   teaspoon    ;   cubic-meter ;   0.00000492892159375 * x ;   0.004928922
+volume  ;   centiliter  ;   cubic-meter ;   0.00001 * x ;   0.01
+volume  ;   tablespoon  ;   cubic-meter ;   0.00001478676478125 * x ;   0.01478676
+volume  ;   cubic-inch  ;   cubic-meter ;   0.000016387064 * x  ;   0.01638706
+volume  ;   fluid-ounce-imperial    ;   cubic-meter ;   0.0000284130625 * x ;   0.02841306
+volume  ;   fluid-ounce ;   cubic-meter ;   0.0000295735295625 * x  ;   0.02957353
+volume  ;   deciliter   ;   cubic-meter ;   0.0001 * x  ;   0.1
+volume  ;   cup ;   cubic-meter ;   0.0002365882365 * x ;   0.2365882
+volume  ;   cup-metric  ;   cubic-meter ;   0.00025 * x ;   0.25
+volume  ;   pint    ;   cubic-meter ;   0.000473176473 * x  ;   0.4731765
+volume  ;   pint-metric ;   cubic-meter ;   0.0005 * x  ;   0.5
+volume  ;   quart   ;   cubic-meter ;   0.000946352946 * x  ;   0.9463529
+volume  ;   liter   ;   cubic-meter ;   0.001 * x   ;   1.0
+volume  ;   gallon  ;   cubic-meter ;   0.003785411784 * x  ;   3.785412
+volume  ;   gallon-imperial ;   cubic-meter ;   0.00454609 * x  ;   4.54609
+volume  ;   cubic-foot  ;   cubic-meter ;   0.028316846592 * x  ;   28.31685
+volume  ;   bushel  ;   cubic-meter ;   0.03523907016688 * x    ;   35.23907
+volume  ;   hectoliter  ;   cubic-meter ;   0.1 * x ;   100.0
+volume  ;   barrel  ;   cubic-meter ;   0.158987294928 * x  ;   158.9873
+volume  ;   cubic-yard  ;   cubic-meter ;   0.764554857984 * x  ;   764.5549
 volume  ;   cubic-meter ;   cubic-meter ;   1 * x   ;   1,000.00
-volume  ;   megaliter   ;   cubic-meter ;   1000 * x    ;   1000000.0
-volume  ;   acre-foot   ;   cubic-meter ;   60228605349 / 48828125 * x  ;   1233482.0
-volume  ;   cubic-kilometer ;   cubic-meter ;   1000000000 * x  ;   1.0E12
-volume  ;   cubic-mile  ;   cubic-meter ;   8140980127813632 / 1953125 * x  ;   4.168182E12
-year-duration   ;   month   ;   year    ;   1 / 12 * x  ;   83.33333
-year-duration   ;   month-person    ;   year    ;   1 / 12 * x  ;   83.33333
+volume  ;   megaliter   ;   cubic-meter ;   1,000 * x   ;   1000000.0
+volume  ;   acre-foot   ;   cubic-meter ;   1,233.48183754752 * x   ;   1233482.0
+volume  ;   cubic-kilometer ;   cubic-meter ;   1,000,000,000 * x   ;   1.0E12
+volume  ;   cubic-mile  ;   cubic-meter ;   4,168,181,825.440579584 * x ;   4.168182E12
+year-duration   ;   month   ;   year    ;   0.25/3 * x  ;   83.33333
+year-duration   ;   month-person    ;   year    ;   0.25/3 * x  ;   83.33333
 year-duration   ;   year    ;   year    ;   1 * x   ;   1,000.00
 year-duration   ;   year-person ;   year    ;   1 * x   ;   1000.0
 year-duration   ;   decade  ;   year    ;   10 * x  ;   10000.0

--- a/icu4c/source/test/testdata/units/unitsTest.txt
+++ b/icu4c/source/test/testdata/units/unitsTest.txt
@@ -29,8 +29,8 @@ area    ;   acre    ;   square-meter    ;   316160658 / 78125 * x   ;   4046856.
 area    ;   hectare ;   square-meter    ;   10000 * x   ;   1.0E7
 area    ;   square-kilometer    ;   square-meter    ;   1000000 * x ;   1.0E9
 area    ;   square-mile ;   square-meter    ;   40468564224 / 15625 * x ;   2.589988E9
-#WIP(ILLEGAL_ARG)#concentration   ;   millimole-per-liter ;   item-per-cubic-meter    ;   602214076000000000000000 * x    ;   6.022141E26
-#WIP(ILLEGAL_ARG)#consumption ;   liter-per-100-kilometer ;   cubic-meter-per-meter   ;   1 / 100000000 * x   ;   1.0E-5
+concentration   ;   millimole-per-liter ;   item-per-cubic-meter    ;   602214076000000000000000 * x    ;   6.022141E26
+consumption ;   liter-per-100-kilometer ;   cubic-meter-per-meter   ;   1 / 100000000 * x   ;   1.0E-5
 consumption ;   liter-per-kilometer ;   cubic-meter-per-meter   ;   1 / 1000000 * x ;   0.001
 consumption-inverse ;   mile-per-gallon-imperial    ;   meter-per-cubic-meter   ;   160934400000 / 454609 * x   ;   3.540062E8
 consumption-inverse ;   mile-per-gallon ;   meter-per-cubic-meter   ;   48000000000 / 112903 * x    ;   4.251437E8
@@ -114,11 +114,11 @@ mass    ;   metric-ton  ;   kilogram    ;   1000 * x    ;   1000000.0
 mass    ;   earth-mass  ;   kilogram    ;   5972200000000000000000000 * x   ;   5.9722E27
 mass    ;   solar-mass  ;   kilogram    ;   1988470000000000000000000000000 * x ;   1.98847E33
 mass-density    ;   milligram-per-deciliter ;   kilogram-per-cubic-meter    ;   1 / 100 * x ;   10.0
-#WIP(ILLEGAL_ARG)#portion ;   permillion  ;   portion ;   1 / 1000000 * x ;   0.001
-#WIP(ILLEGAL_ARG)#portion ;   permyriad   ;   portion ;   1 / 10000 * x   ;   0.1
-#WIP(ILLEGAL_ARG)#portion ;   permille    ;   portion ;   1 / 1000 * x    ;   1.0
-#WIP(ILLEGAL_ARG)#portion ;   percent ;   portion ;   1 / 100 * x ;   10.0
-#WIP(ILLEGAL_ARG)#portion ;   karat   ;   portion ;   1 / 24 * x  ;   41.66667
+portion ;   permillion  ;   portion ;   1 / 1000000 * x ;   0.001
+portion ;   permyriad   ;   portion ;   1 / 10000 * x   ;   0.1
+portion ;   permille    ;   portion ;   1 / 1000 * x    ;   1.0
+portion ;   percent ;   portion ;   1 / 100 * x ;   10.0
+portion ;   karat   ;   portion ;   1 / 24 * x  ;   41.66667
 power   ;   milliwatt   ;   kilogram-square-meter-per-cubic-second  ;   1 / 1000 * x    ;   1.0
 power   ;   watt    ;   kilogram-square-meter-per-cubic-second  ;   1 * x   ;   1000.0
 power   ;   horsepower  ;   kilogram-square-meter-per-cubic-second  ;   37284993579113511 / 50000000000000 * x  ;   745699.9
@@ -127,11 +127,11 @@ power   ;   megawatt    ;   kilogram-square-meter-per-cubic-second  ;   1000000 
 power   ;   gigawatt    ;   kilogram-square-meter-per-cubic-second  ;   1000000000 * x  ;   1.0E12
 power   ;   solar-luminosity    ;   kilogram-square-meter-per-cubic-second  ;   382800000000000000000000000 * x ;   3.828E29
 pressure    ;   pascal  ;   kilogram-per-meter-square-second    ;   1 * x   ;   1000.0
-#WIP(ILLEGAL_ARG)#pressure    ;   millimeter-ofhg   ;   kilogram-per-meter-square-second    ;   4053 / 304 * x  ;   13332.24
+pressure    ;   millimeter-ofhg   ;   kilogram-per-meter-square-second    ;   4053 / 304 * x  ;   13332.24
 pressure    ;   hectopascal ;   kilogram-per-meter-square-second    ;   100 * x ;   100000.0
 pressure    ;   millibar    ;   kilogram-per-meter-square-second    ;   100 * x ;   100000.0
 pressure    ;   kilopascal  ;   kilogram-per-meter-square-second    ;   1000 * x    ;   1000000.0
-#WIP(ILLEGAL_ARG)#pressure    ;   inch-ofhg   ;   kilogram-per-meter-square-second    ;   3386389 / 1000 * x  ;   338638.8
+pressure    ;   inch-ofhg   ;   kilogram-per-meter-square-second    ;   3386389 / 1000 * x  ;   338638.8
 pressure    ;   pound-force-per-square-inch ;   kilogram-meter-per-square-meter-square-second   ;   8896443230521 / 1290320000 * x  ;   6894757.0
 pressure    ;   bar ;   kilogram-per-meter-square-second    ;   100000 * x  ;   1.0E8
 pressure    ;   atmosphere  ;   kilogram-per-meter-square-second    ;   101325 * x  ;   1.01325E8
@@ -144,7 +144,7 @@ speed   ;   kilometer-per-hour  ;   meter-per-second    ;   5 / 18 * x  ;   277.
 speed   ;   mile-per-hour   ;   meter-per-second    ;   1397 / 3125 * x ;   447.04
 speed   ;   knot    ;   meter-per-second    ;   463 / 900 * x   ;   514.4444
 speed   ;   meter-per-second    ;   meter-per-second    ;   1 * x   ;   1,000.00
-#WIP(ILLEGAL_ARG)#substance-amount    ;   mole    ;   item    ;   602214076000000000000000 * x    ;   6.022141E26
+substance-amount    ;   mole    ;   item    ;   602214076000000000000000 * x    ;   6.022141E26
 temperature ;   fahrenheit  ;   kelvin  ;   5 / 9 * x - 45967 / 180 ;   810.9278
 temperature ;   kelvin  ;   kelvin  ;   1 * x   ;   1,000.00
 temperature ;   celsius ;   kelvin  ;   1 * x - 5463 / 20   ;   1273.15


### PR DESCRIPTION
With this update to tests, format/UnitsTest/testConversions gets 41 failures. I've looked into volt (as commented), several others would probably have the same issue (compound base units).

This pull request contains cherry-picks of https://github.com/sffc/icu/pull/34 and https://github.com/sffc/icu/pull/33. Please review those two, after which the relevant commit remaining here will be 4a8aab5.