### PR TITLE
extractBaseUnit: fix the compound-baseUnit case.

### DIFF
--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -39,6 +39,7 @@ MeasureUnit extractBaseUnit(const MeasureUnit &source,
 
     for (int i = 0; i < count; ++i) {
         const auto &singleUnit = singleUnits[i];
+        int32_t dimensionality = singleUnit.getDimensionality(status);
         // Extract `ConversionRateInfo` using the absolute unit. For example: in case of `square-meter`,
         // we will use `meter`
         const auto singleUnitImpl = SingleUnitImpl::forMeasureUnit(singleUnit, status);
@@ -49,10 +50,24 @@ MeasureUnit extractBaseUnit(const MeasureUnit &source,
         // Multiply the power of the singleUnit by the power of the baseUnit. For example, square-hectare
         // must be p4-meter. (NOTE: hectare --> square-meter)
         auto baseUnit = MeasureUnit::forIdentifier(rateInfo.baseUnit.toStringPiece(), status);
-        auto singleBaseUnit = SingleUnitImpl::forMeasureUnit(baseUnit, status);
-        singleBaseUnit.dimensionality *= singleUnit.getDimensionality(status);
+        if (dimensionality != 1) {
+            if (baseUnit.getComplexity(status) == UMEASURE_UNIT_SINGLE) {
+                baseUnit = baseUnit.withDimensionality(
+                    dimensionality * baseUnit.getDimensionality(status), status);
+            } else {
+                // Single units like volt, joule, newton, and knots map to
+                // compound base units. Fortunately square-volt, square-joule,
+                // square-newton, and square-knots don't generally make sense.
+                // We treat them as illegal.
+                status = U_ILLEGAL_ARGUMENT_ERROR;
+                return MeasureUnit();
+                // TODO(younies,hugovdm): (dimensionality = -1) might appear
+                // though? one-per-joule, one-per-volt? Consider this. Find some
+                // reasonable real-world usages that would trigger this problem.
+            }
+        }
 
-        result = result.product(singleBaseUnit.build(status), status);
+        result = result.product(baseUnit, status);
     }
 
     return result;


### PR DESCRIPTION
This makes (almost all of)* the unit tests pass in my other pull request.

*It seems I've found another bug in MeasureFormat.