### PR TITLE
Enable "testConversions" test again

### DIFF
--- a/icu4c/source/test/intltest/unitstest.cpp
+++ b/icu4c/source/test/intltest/unitstest.cpp
@@ -27,7 +27,8 @@ class UnitsTest : public IntlTest {
     void runIndexedTest(int32_t index, UBool exec, const char *&name, char *par = NULL);
 
     void testConversionCapability();
-    //  void testConversions(); // TODO(hugo): it doesnot pass.
+    // TODO(hugovdm,younies): add conversion testing (only convertability atm).
+    void testConversions();
     void testPreferences();
     // void testBasic();
     // void testSiPrefixes();
@@ -42,7 +43,7 @@ void UnitsTest::runIndexedTest(int32_t index, UBool exec, const char *&name, cha
     if (exec) { logln("TestSuite UnitsTest: "); }
     TESTCASE_AUTO_BEGIN;
     TESTCASE_AUTO(testConversionCapability);
-    // TESTCASE_AUTO(testConversions);
+    TESTCASE_AUTO(testConversions);
     TESTCASE_AUTO(testPreferences);
     // TESTCASE_AUTO(testBasic);
     // TESTCASE_AUTO(testSiPrefixes);
@@ -269,8 +270,8 @@ StringPiece trimField(char *(&field)[2]) {
 }
 
 /**
- * WIP(hugovdm): deals with a single data-driven unit test for unit conversions.
- * This is a UParseLineFn as required by u_parseDelimitedFile.
+ * Deals with a single data-driven unit test for unit conversions. This
+ * UParseLineFn for use by u_parseDelimitedFile is intended for "unitsTest.txt".
  */
 void unitsTestDataLineFn(void *context, char *fields[][2], int32_t fieldCount, UErrorCode *pErrorCode) {
     if (U_FAILURE(*pErrorCode)) return;
@@ -323,38 +324,42 @@ void unitsTestDataLineFn(void *context, char *fields[][2], int32_t fieldCount, U
 
     unitsTest->assertTrue(msg.data(), actualState != UNCONVERTIBLE);
 
-    // Unit conversion... untested:
+    // TODO(hugovdm,younies): add conversion testing in unitsTestDataLineFn:
+    //
     // UnitConverter converter(sourceUnit, targetUnit, status);
     // double got = converter.convert(1000, status);
     // unitsTest->assertEqualsNear(quantity.data(), expected, got, 0.0001);
 }
 
-// /**
-//  * Runs data-driven unit tests for unit conversion. It looks for the test cases
-//  * in source/test/testdata/units/unitsTest.txt, which originates in CLDR.
-//  */
-// void UnitsTest::testConversions() {
-//     const char *filename = "unitsTest.txt";
-//     const int32_t kNumFields = 5;
-//     char *fields[kNumFields][2];
+/**
+ * Runs data-driven unit tests for unit conversion. It looks for the test cases
+ * in source/test/testdata/units/unitsTest.txt, which originates in CLDR.
+ *
+ * TODO(hugovdm,younies): add conversion testing in unitsTestDataLineFn (it only
+ * tests convertability at the moment).
+ */
+void UnitsTest::testConversions() {
+    const char *filename = "unitsTest.txt";
+    const int32_t kNumFields = 5;
+    char *fields[kNumFields][2];
 
-//     IcuTestErrorCode errorCode(*this, "UnitsTest::testConversions");
-//     const char *sourceTestDataPath = getSourceTestData(errorCode);
-//     if (errorCode.errIfFailureAndReset("unable to find the source/test/testdata "
-//                                        "folder (getSourceTestData())")) {
-//         return;
-//     }
+    IcuTestErrorCode errorCode(*this, "UnitsTest::testConversions");
+    const char *sourceTestDataPath = getSourceTestData(errorCode);
+    if (errorCode.errIfFailureAndReset("unable to find the source/test/testdata "
+                                       "folder (getSourceTestData())")) {
+        return;
+    }
 
-//     CharString path(sourceTestDataPath, errorCode);
-//     path.appendPathPart("units", errorCode);
-//     path.appendPathPart(filename, errorCode);
+    CharString path(sourceTestDataPath, errorCode);
+    path.appendPathPart("units", errorCode);
+    path.appendPathPart(filename, errorCode);
 
-//     u_parseDelimitedFile(path.data(), ';', fields, kNumFields, unitsTestDataLineFn, this, errorCode);
-//     if (errorCode.errIfFailureAndReset("error parsing %s: %s\n", path.data(), u_errorName(errorCode)))
-//     {
-//         return;
-//     }
-// }
+    u_parseDelimitedFile(path.data(), ';', fields, kNumFields, unitsTestDataLineFn, this, errorCode);
+    if (errorCode.errIfFailureAndReset("error parsing %s: %s\n", path.data(), u_errorName(errorCode)))
+    {
+        return;
+    }
+}
 
 /**
  * This class represents the output fields from unitPreferencesTest.txt. Please


### PR DESCRIPTION
With MeasureUnit fixes merged, these tests seem to pass now.

Adding unit tests to sffc#32