### PR TITLE
Reinstate assertEqualsNear that got lost in merge.

### DIFF
--- a/icu4c/source/test/intltest/intltest.cpp
+++ b/icu4c/source/test/intltest/intltest.cpp
@@ -2173,6 +2173,25 @@ UBool IntlTest::assertNotEquals(const char* message,
     return TRUE;
 }
 
+// TODO: how about we adjust this function to align with JUnit? I see it simply has "assertEquals" for
+// doulbes with a "delta" parameter:
+// http://junit.sourceforge.net/javadoc/org/junit/Assert.html#assertEquals(java.lang.String,%20double,%20double,%20double)
+UBool IntlTest::assertEqualsNear(const char *message, double expected, double actual, double precision) {
+    double diff = std::abs(expected - actual);
+    double diffPercent = expected != 0? diff / expected : diff; // If the expected is equals zero, we
+
+    if (diffPercent > precision) {
+        errln((UnicodeString) "FAIL: " + message + "; got " + actual + "; expected " + expected);
+        return FALSE;
+    }
+#ifdef VERBOSE_ASSERTIONS
+    else {
+        logln((UnicodeString) "Ok: " + message + "; got " + expected);
+    }
+#endif
+    return TRUE;
+}
+
 static char ASSERT_BUF[256];
 
 static const char* extractToAssertBuf(const UnicodeString& message) {


### PR DESCRIPTION
- Code compiles, `make check` returns OK.
