### PR TITLE
Test UnitsRouter constructor and fix category/preferences handling

### DIFF
--- a/icu4c/source/i18n/unitconverter.cpp
+++ b/icu4c/source/i18n/unitconverter.cpp
@@ -176,6 +176,11 @@ double strHasDivideSignToDouble(StringPiece strWithDivide, UErrorCode &status) {
     return strToDouble(strWithDivide, status);
 }
 
+} // namespace
+// FIXME/TODO: this namespace closing and reopening hack makes below
+// function "public" with easy-to-read diffs. But better to move it to other
+// public functions.
+
 /**
  * Extracts the compound base unit of a compound unit (`source`). For example, if the source unit is
  * `square-mile-per-hour`, the compound base unit will be `square-meter-per-second`
@@ -216,6 +221,9 @@ MeasureUnit extractCompoundBaseUnit(const MeasureUnit &source, const ConversionR
 
     return result;
 }
+
+// FIXME/TODO: fix this before merging the PR!
+namespace {
 
 // TODO: Load those constant from units data.
 /*

--- a/icu4c/source/i18n/unitconverter.h
+++ b/icu4c/source/i18n/unitconverter.h
@@ -34,6 +34,9 @@ enum U_I18N_API UnitsConvertibilityState {
     UNCONVERTIBLE,
 };
 
+MeasureUnit extractCompoundBaseUnit(const MeasureUnit &source, const ConversionRates &conversionRates,
+                                    UErrorCode &status);
+
 UnitsConvertibilityState U_I18N_API checkConvertibility(const MeasureUnit &source,
                                                         const MeasureUnit &target,
                                                         const ConversionRates &conversionRates,

--- a/icu4c/source/i18n/unitsdata.cpp
+++ b/icu4c/source/i18n/unitsdata.cpp
@@ -375,6 +375,30 @@ const ConversionRateInfo *ConversionRates::extractConversionInfo(StringPiece sou
     return nullptr;
 }
 
+// TODO/FIXME: baseUnitIdentifier seems onerous? If this function could access
+// extractCompoundBaseUnit directly, we could support any input unit identifier.
+// Shall we move extractCompoundBaseUnit to unitsdata.cpp?
+CharString U_I18N_API getUnitCategory(const char *baseUnitIdentifier, UErrorCode &status) {
+    CharString result;
+    LocalUResourceBundlePointer unitsBundle(ures_openDirect(NULL, "units", &status));
+    LocalUResourceBundlePointer unitQuantities(
+        ures_getByKey(unitsBundle.getAlias(), "unitQuantities", NULL, &status));
+    int32_t categoryLength;
+    if (U_FAILURE(status)) { return result; }
+    const UChar *uCategory =
+        ures_getStringByKey(unitQuantities.getAlias(), baseUnitIdentifier, &categoryLength, &status);
+    if (U_FAILURE(status)) {
+        // TODO: manually dealing with consumption-inverse
+        if (uprv_strcmp(baseUnitIdentifier, "meter-per-cubic-meter") == 0) {
+            status = U_ZERO_ERROR;
+            uCategory = ures_getStringByKey(unitQuantities.getAlias(), "cubic-meter-per-meter",
+                                            &categoryLength, &status);
+        }
+    }
+    result.appendInvariantChars(uCategory, categoryLength, status);
+    return result;
+}
+
 U_I18N_API UnitPreferences::UnitPreferences(UErrorCode &status) {
     LocalUResourceBundlePointer unitsBundle(ures_openDirect(NULL, "units", &status));
     UnitPreferencesSink sink(&unitPrefs_, &metadata_);

--- a/icu4c/source/i18n/unitsdata.h
+++ b/icu4c/source/i18n/unitsdata.h
@@ -76,6 +76,8 @@ class U_I18N_API ConversionRates {
     MaybeStackVector<ConversionRateInfo> conversionInfo_;
 };
 
+CharString U_I18N_API getUnitCategory(const char *baseUnitIdentifier, UErrorCode &status);
+
 // Encapsulates unitPreferenceData information from units resources, specifying
 // a sequence of output unit preferences.
 struct U_I18N_API UnitPreference : public UMemory {

--- a/icu4c/source/test/intltest/unitstest.cpp
+++ b/icu4c/source/test/intltest/unitstest.cpp
@@ -570,18 +570,27 @@ void unitPreferencesTestDataLineFn(void *context, char *fields[][2], int32_t fie
         return;
     }
 
-    // WIP(hugovdm): hook this up to actual tests.
-    //
-    // Possible after merging in younies/tryingdouble:
-    // UnitConverter converter(sourceUnit, targetUnit, *pErrorCode);
-    // double got = converter.convert(1000, *pErrorCode);
-    // ((UnitsTest*)context)->assertEqualsNear(quantity.data(), expected, got, 0.0001);
-
     unitsTest->logln("Quantity (Category): \"%.*s\", Usage: \"%.*s\", Region: \"%.*s\", "
                      "Input: \"%f %s\", Expected Output: %s",
                      quantity.length(), quantity.data(), usage.length(), usage.data(), region.length(),
                      region.data(), inputAmount, inputMeasureUnit.getIdentifier(),
                      output.toDebugString().c_str());
+
+    if (U_FAILURE(status)) { return; }
+    UnitsRouter router(inputMeasureUnit, region, usage, status);
+    if (status.errIfFailureAndReset("UnitsRouter(<%s>, \"%.*s\", \"%.*s\", status)",
+                                    inputMeasureUnit.getIdentifier(), region.length(), region.data(),
+                                    usage.length(), usage.data())) {
+        return;
+    }
+    // FIXME/TODO: actually test output. At this point, this causes an assertion
+    // failure in complexunitsconverter.cpp:
+    //
+    // MaybeStackVector<Measure> result = router.route(inputAmount, status);
+    // for (int i=0; i<result.length(); i++) {
+    //     unitsTest->logln("result[%d], number: %f, unit: %s", i, result[i]->getNumber().getDouble(status),
+    //                      result[i]->getUnit().getIdentifier());
+    // }
 }
 
 /**


### PR DESCRIPTION
This shows errors trying to construct certain UnitsRouter instances. Output printed via fprintf.

I will try to get the unitsdata.h/unitsdata.cpp changes submitted upstream via https://github.com/sffc/icu/pull/43